### PR TITLE
Client Certificate Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CredentialProvider Changelog
 
+## 2.0.6 (December 5th 2018)
+
+- Updates
+  - Added support for client certificate authentication.
+  - `UseBasicParsing` parameter added to `Invoke-RestMethod` call.
+
 ## 1.0.0 (April 2018)
 
 Initial Release

--- a/CredentialRetriever/Functions/Get-CCPCredential.ps1
+++ b/CredentialRetriever/Functions/Get-CCPCredential.ps1
@@ -47,6 +47,9 @@
 	.PARAMETER UseDefaultCredentials
 	Use the default credentials for CCP OS User authentication.
 
+	.PARAMETER CertificateThumbPrint
+	A Certificate Thumbprint authorised to access the AIMWebService.
+
 	.PARAMETER WebServiceName
 	The name the CCP WebService is configured under in IIS.
 	Defaults to AIMWebService
@@ -89,6 +92,11 @@
 	Get-CCPCredential -AppID PS -Safe PS -Object PSP-AccountName -URL https://cyberark.yourcompany.com -Credential $creds
 
 	Calls Invoke-RestMethod with the supplied Credentials for OS User authentication
+
+	.EXAMPLE
+	Get-CCPCredential -AppID PS -Safe PS -Object PSP-AccountName -URL https://cyberark.yourcompany.com -CertificateThumbPrint $Cert_ThumbPrint
+
+	Calls Invoke-RestMethod with the supplied Certificate for Certificate authentication
 	#>
 	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification = "Suppress alert from ToSecureString ScriptMethod")]
 	[CmdletBinding(DefaultParameterSetName = "Default")]
@@ -109,6 +117,11 @@
 			ValueFromPipeline = $true,
 			ParameterSetName = "DefaultCredentials"
 		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $true,
+			ParameterSetName = "CertificateThumbPrint"
+		)]
 		[string]
 		$AppID,
 
@@ -127,6 +140,11 @@
 			Mandatory = $false,
 			ValueFromPipeline = $true,
 			ParameterSetName = "DefaultCredentials"
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $true,
+			ParameterSetName = "CertificateThumbPrint"
 		)]
 		[string]
 		$Safe,
@@ -147,6 +165,11 @@
 			ValueFromPipeline = $true,
 			ParameterSetName = "DefaultCredentials"
 		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $true,
+			ParameterSetName = "CertificateThumbPrint"
+		)]
 		[string]
 		$Folder,
 
@@ -165,6 +188,11 @@
 			Mandatory = $false,
 			ValueFromPipeline = $true,
 			ParameterSetName = "DefaultCredentials"
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $true,
+			ParameterSetName = "CertificateThumbPrint"
 		)]
 		[string]
 		$Object,
@@ -185,6 +213,11 @@
 			ValueFromPipeline = $true,
 			ParameterSetName = "DefaultCredentials"
 		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $true,
+			ParameterSetName = "CertificateThumbPrint"
+		)]
 		[string]
 		$UserName,
 
@@ -203,6 +236,11 @@
 			Mandatory = $false,
 			ValueFromPipeline = $true,
 			ParameterSetName = "DefaultCredentials"
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $true,
+			ParameterSetName = "CertificateThumbPrint"
 		)]
 		[string]
 		$Address,
@@ -223,6 +261,11 @@
 			ValueFromPipeline = $true,
 			ParameterSetName = "DefaultCredentials"
 		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $true,
+			ParameterSetName = "CertificateThumbPrint"
+		)]
 		[string]
 		$Database,
 
@@ -241,6 +284,11 @@
 			Mandatory = $false,
 			ValueFromPipeline = $true,
 			ParameterSetName = "DefaultCredentials"
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $true,
+			ParameterSetName = "CertificateThumbPrint"
 		)]
 		[string]
 		$PolicyID,
@@ -261,6 +309,11 @@
 			ValueFromPipeline = $true,
 			ParameterSetName = "DefaultCredentials"
 		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $true,
+			ParameterSetName = "CertificateThumbPrint"
+		)]
 		[string]
 		$Reason,
 
@@ -279,6 +332,11 @@
 			Mandatory = $false,
 			ValueFromPipeline = $true,
 			ParameterSetName = "DefaultCredentials"
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $true,
+			ParameterSetName = "CertificateThumbPrint"
 		)]
 		[int]
 		$ConnectionTimeout,
@@ -302,6 +360,15 @@
 		[Switch]
 		$UseDefaultCredentials,
 
+		# Use certificate to authenticate to CCP
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $true,
+			ParameterSetName = "CertificateThumbPrint"
+		)]
+		[string]
+		$CertificateThumbPrint,
+
 		# Unique ID of the CCP webservice in IIS
 		[Parameter(
 			Mandatory = $false,
@@ -317,6 +384,11 @@
 			Mandatory = $false,
 			ValueFromPipeline = $true,
 			ParameterSetName = "DefaultCredentials"
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $true,
+			ParameterSetName = "CertificateThumbPrint"
 		)]
 		[string]
 		$WebServiceName = "AIMWebService",
@@ -337,6 +409,11 @@
 			ValueFromPipeline = $true,
 			ParameterSetName = "DefaultCredentials"
 		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $true,
+			ParameterSetName = "CertificateThumbPrint"
+		)]
 		[string]
 		$URL
 	)
@@ -346,7 +423,7 @@
 		#Collection of parameters which are to be excluded from the request URL
 		[array]$CommonParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
 		[array]$CommonParameters += [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
-		[array]$CommonParameters += "URL", "WebServiceName", "Credential", "UseDefaultCredentials"
+		[array]$CommonParameters += "URL", "WebServiceName", "Credential", "UseDefaultCredentials", "CertificateThumbPrint"
 
 		#If Tls12 Security Protocol is available
 		if(([Net.SecurityProtocolType].GetEnumNames() -contains "Tls12") -and
@@ -376,23 +453,24 @@
 
 		#Create hashtable of request parameters
 		$Request = @{
-			"URI"         = "$URL/$WebServiceName/api/Accounts?$Query"
-			"Method"      = "GET"
-			"ContentType" = "application/json"
-			"ErrorAction" = "Stop"
+			"URI"           = "$URL/$WebServiceName/api/Accounts?$Query"
+			"Method"        = "GET"
+			"ContentType"   = "application/json"
+			"ErrorAction"   = "Stop"
+			"ErrorVariable" = "RequestError"
 		}
 
-		#Add Credential to request is provided
-		If($($PSCmdlet.ParameterSetName) -eq "Credential") {
-
-			$Request["Credential"] = $Credential
-
+		#Add authentication parameters to request
+		Switch($($PSCmdlet.ParameterSetName)) {
+			'Credential' { $Request["Credential"] = $Credential}
+			'DefaultCredentials' {$Request["UseDefaultCredentials"] = $true}
+			'CertificateThumbPrint' {$Request["CertificateThumbPrint"] = $CertificateThumbPrint}
 		}
 
-		#Add UseDefaultCredentials switch to request if specified
-		ElseIf($($PSCmdlet.ParameterSetName) -eq "DefaultCredentials") {
+		#in PSCore Use SslProtocol TLS1.2
+		if ($IsCoreCLR) {
 
-			$Request["UseDefaultCredentials"] = $true
+			$Request.Add("SslProtocol", "TLS12")
 
 		}
 
@@ -404,15 +482,10 @@
 		} Catch {
 
 			try {
-
-				#output error message
-				$err = $_ | ConvertFrom-Json -ErrorAction SilentlyContinue
+				$err = $_ | ConvertFrom-Json -ErrorAction Stop
 				Write-Error -Message $err.ErrorMsg -ErrorId $err.ErrorCode
+			} catch {Write-Error -Message $RequestError.ErrorRecord.Exception -ErrorId $RequestError.ErrorRecord.FullyQualifiedErrorId -ErrorAction Stop}
 
-				#if JSON conversion fails throw original exception
-			} catch {throw $error[-1]}
-
-			#output result
 		} Finally {
 
 			if($result) {

--- a/CredentialRetriever/Functions/Get-CCPCredential.ps1
+++ b/CredentialRetriever/Functions/Get-CCPCredential.ps1
@@ -441,10 +441,12 @@
 
 	Process {
 
+		[array]$QueryArgs = @()
+
 		#Enumerate bound parameters to build query string for URL
 		$PSBoundParameters.keys | Where-Object {$CommonParameters -notcontains $_} | ForEach-Object {
 
-			[array]$QueryArgs += "$_=$([System.Uri]::EscapeDataString($PSBoundParameters[$_]))"
+			$QueryArgs += "$_=$([System.Uri]::EscapeDataString($PSBoundParameters[$_]))"
 
 		}
 

--- a/CredentialRetriever/Functions/Get-CCPCredential.ps1
+++ b/CredentialRetriever/Functions/Get-CCPCredential.ps1
@@ -455,11 +455,12 @@
 
 		#Create hashtable of request parameters
 		$Request = @{
-			"URI"           = "$URL/$WebServiceName/api/Accounts?$Query"
-			"Method"        = "GET"
-			"ContentType"   = "application/json"
-			"ErrorAction"   = "Stop"
-			"ErrorVariable" = "RequestError"
+			"URI"             = "$URL/$WebServiceName/api/Accounts?$Query"
+			"Method"          = "GET"
+			"ContentType"     = "application/json"
+			"ErrorAction"     = "Stop"
+			"ErrorVariable"   = "RequestError"
+			"UseBasicParsing" = $true
 		}
 
 		#Add authentication parameters to request

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 1.0.{build}
+version: 2.0.{build}
 
 environment:
   access_token:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ skip_commits:
     - ISSUE_TEMPLATE.md
     - PULL_REQUEST_TEMPLATE.md
     - appveyor.yml
+    - CHANGELOG.md
   message: /update readme.*|update version.*|update appveyor.*/
 
 only_commits:
@@ -28,16 +29,16 @@ only_commits:
     - CredentialRetriever\
     - tests\
 
-os: WMF 5
+image: Visual Studio 2017
 
 install:
-  - ps: . .\build\install.ps1
+  - pwsh.exe -File .\build\install.ps1
 
 build_script:
-  - ps: . .\build\build.ps1
+  - pwsh.exe -File .\build\build.ps1
 
 test_script:
-  - ps: . .\build\test.ps1
+  - pwsh.exe -File .\build\test.ps1
 
 deploy_script:
-  - ps: . .\build\deploy.ps1
+  - pwsh.exe -File .\build\deploy.ps1

--- a/build/install.ps1
+++ b/build/install.ps1
@@ -6,12 +6,19 @@ Write-Host "Installing:" -ForegroundColor Yellow
 #---------------------------------#
 # Install NuGet                   #
 #---------------------------------#
-Write-Host "`tNuGet..."
-$pkg = Install-PackageProvider -Name NuGet -Confirm:$false -Force -ErrorAction Stop
-Write-Host "`t`tInstalled NuGet version '$($pkg.version)'"
-
+if(-not $IsCoreCLR) {
+	Write-Host "`tNuGet..."
+	$pkg = Install-PackageProvider -Name NuGet -Confirm:$false -Force -ErrorAction Stop
+	Write-Host "`t`tInstalled NuGet version '$($pkg.version)'"
+}
 #---------------------------------#
 # Install Required Modules        #
 #---------------------------------#
-Write-Host "`tRequired Modules..."
-Install-Module -Name Pester, PSScriptAnalyzer, coveralls -Repository PSGallery -Confirm:$false -Force -ErrorAction SilentlyContinue | Out-Null
+Try {
+	Write-Host "`tRequired Module: Pester..."
+	Install-Module -Name Pester -Repository PSGallery -Confirm:$false -Force -ErrorAction Stop | Out-Null
+	Write-Host "`tRequired Module: PSScriptAnalyzer..."
+	Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Confirm:$false -Force -SkipPublisherCheck -ErrorAction Stop | Out-Null
+	Write-Host "`tRequired Module: coveralls..."
+	Install-Module -Name coveralls -Repository PSGallery -Confirm:$false -Force -ErrorAction Stop | Out-Null
+} Catch {throw "`t`tError Installing Module"}


### PR DESCRIPTION
## Summary

- Added support for specifying CertificateThumbPrint for client certificate authentication to be used when sending a request to the web service.

## Test Plan

Pester Tests updated, code coverage increased to 100%

## Closes issues

Closes #2 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->