### PR TITLE
UPDATE Get-AIMCredential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CredentialRetriever Changelog
 
+## 3.2.11 (April 30th 2019)
+
+- Fix `Get-AIMCredential`
+  - Adds support for spaces in application names.
+
 ## 3.1.9 (April 9th 2019)
 
 - Updates

--- a/CredentialRetriever/Functions/Get-AIMCredential.ps1
+++ b/CredentialRetriever/Functions/Get-AIMCredential.ps1
@@ -194,14 +194,14 @@ Function Get-AIMCredential {
 		#Array to hold the Properties to return
 		[array]$ReturnProps = @()
 		#Hashtable to hold the Results to Output
-		[hashtable]$Output = @{}
+		[hashtable]$Output = @{ }
 
 	}
 
 	Process {
 
 		#Initial Command String
-		$Command = "/p AppDescs.AppID=$AppID"
+		$Command = "/p AppDescs.AppID=`"$AppID`""
 
 		Write-Debug $Command
 
@@ -209,7 +209,7 @@ Function Get-AIMCredential {
 		$PSBoundParameters.Add("Query", @())
 		$QueryParameters | ForEach-Object {
 
-			If($PSBoundParameters.ContainsKey("$_")) {
+			If ($PSBoundParameters.ContainsKey("$_")) {
 
 
 				$PSBoundParameters["Query"] += "$_=$($PSBoundParameters["$_"])"
@@ -250,7 +250,7 @@ Function Get-AIMCredential {
 
 			}
 
-			{$ConnectionParms -contains $PSItem} {
+			{ $ConnectionParms -contains $PSItem } {
 
 				$Command = "$Command /p ConnectionParms.$_=$($PSBoundParameters[$_])"
 
@@ -276,7 +276,7 @@ Function Get-AIMCredential {
 		$Result = Invoke-AIMClient @PSBoundParameters
 
 		#Output on StdOut
-		If($Result.StdOut) {
+		If ($Result.StdOut) {
 
 			#split returned results
 			$Results = ($Result.StdOut).Split(",")
@@ -284,7 +284,7 @@ Function Get-AIMCredential {
 			#use $returnProps to determine propertynames
 			$ReturnProps = $ReturnProps.Split(",")
 
-			For($i = 0 ; $i -lt $Results.length ; $i++) {
+			For ($i = 0 ; $i -lt $Results.length ; $i++) {
 
 				#PropertyName=PropertyValue
 				$Output[$(($ReturnProps[$i]) -replace "PassProps.", "")] = ($Results[$i]).trim()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 3.1.{build}
+version: 3.2.{build}
 
 environment:
   access_token:


### PR DESCRIPTION
## Summary

Adds support for spaces in application names

## Test Plan

Retrieves credential when using an application name with a space in it.

## Closes issues

Closes #7 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->