### PR TITLE
FIX Get-AIMCredential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CredentialRetriever Changelog
 
-## 3.5.2X (April 17th 2020)
+## 3.5.25 (April 18th 2020)
 
 - Fix `Get-AIMCredential`
   - Fix output parsing bug introduced in `3.5.22`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CredentialRetriever Changelog
 
+## 3.5.2X (April 17th 2020)
+
+- Fix `Get-AIMCredential`
+  - Fix output parsing bug introduced in `3.5.22`.
+
 ## 3.5.22 (April 10th 2020)
 
 - Fix `Get-AIMCredential`

--- a/CredentialRetriever/Functions/Get-AIMCredential.ps1
+++ b/CredentialRetriever/Functions/Get-AIMCredential.ps1
@@ -197,8 +197,6 @@ Function Get-AIMCredential {
 		[hashtable]$Output = @{ }
 		#Delimiter for separating the output fields
 		$Separator = "#_-_#"
-		#Set StringSplitOption
-		$RemoveEmptyEntries = [System.StringSplitOptions]::RemoveEmptyEntries
 
 	}
 
@@ -280,7 +278,7 @@ Function Get-AIMCredential {
 		If ($Result.StdOut) {
 
 			#split returned results at Separator
-			$Results = ($Result.StdOut).Split($Separator, $RemoveEmptyEntries)
+			$Results = ($Result.StdOut) -Split $Separator
 
 			#use $returnProps to determine propertynames
 			$ReturnProps = $ReturnProps.Split(",")


### PR DESCRIPTION
Use `-split` instead of `.split()`.
Fix output parsing bug introduced in previous release.
Closes #16