### PR TITLE
Get-CCPCredential Query Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Update `Get-AIMCredential`
   - Resolves issue where specifying a value for the `-Reason` parameter which includes a space resulted in an error.
 
+- Update `Get-CCPCredential`
+  - Adds `Query` parameter to allow users to specify own query filter value to include in request URL.
+
 ## 3.8.36
 
 - Update to avoid an observed unexpected error behaviour.

--- a/CredentialRetriever/CredentialRetriever.psd1
+++ b/CredentialRetriever/CredentialRetriever.psd1
@@ -16,7 +16,7 @@
 	# CompanyName = ''
 
 	# Copyright statement for this module
-	Copyright         = '(c) 2018-2021 Pete Maan. All rights reserved.'
+	Copyright         = '(c) 2018-2022 Pete Maan. All rights reserved.'
 
 	# Description of the functionality provided by this module
 	Description       = 'Retrieve Credentials from CyberArk Central Credential Provider via REST, or Local Credential Provider using CLIPasswordSDK'

--- a/CredentialRetriever/Functions/Get-CCPCredential.ps1
+++ b/CredentialRetriever/Functions/Get-CCPCredential.ps1
@@ -36,6 +36,9 @@
 	.PARAMETER Reason
 	The reason for retrieving the password. This reason will be audited in the Credential Provider audit log
 
+	.PARAMETER Query
+	A query value to be specified in the URL to filter the result.
+
 	.PARAMETER ConnectionTimeout
 	The number of seconds that the Central Credential Provider will try to retrieve the password.
 	The timeout is calculated when the request is sent from the web service to the Vault and returned back
@@ -114,6 +117,12 @@
 	Get-CCPCredential -AppID PS -Safe PS -Object PSP-AccountName -URL https://cyberark.yourcompany.com -Certificate $Cert
 
 	Calls Invoke-RestMethod with the supplied Certificate for Certificate authentication
+
+	.EXAMPLE
+	Get-CCPCredential -Query 'AppID=PS&Object=PSP-AccountName&Safe=PS&QueryFormat=Exact' -URL https://cyberark.yourcompany.com
+
+	Calls Invoke-RestMethod with the supplied Certificate for Certificate authentication
+
 	#>
 	[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'Suppress alert from ToSecureString ScriptMethod')]
 	[CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -379,6 +388,34 @@
 		[string]
 		$Reason,
 
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Query'
+		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCredential'
+		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryDefaultCredentials'
+		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCertificateThumbPrint'
+		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCertificate'
+		)]
+		[string]
+		$Query,
+
 		# Number of seconds to try
 		[Parameter(
 			Mandatory = $false,
@@ -405,6 +442,31 @@
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Certificate'
 		)]
+		[Parameter(
+			Mandatory = $false,
+			ValueFromPipelineByPropertyName = $true,
+			ParameterSetName = 'Query'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCredential'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryDefaultCredentials'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCertificateThumbPrint'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCertificate'
+		)]
 		[int]
 		$ConnectionTimeout,
 
@@ -413,6 +475,11 @@
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Credential'
+		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCredential'
 		)]
 		[ValidateNotNullOrEmpty()]
 		[PSCredential]
@@ -424,6 +491,11 @@
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'DefaultCredentials'
 		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryDefaultCredentials'
+		)]
 		[Switch]
 		$UseDefaultCredentials,
 
@@ -433,6 +505,11 @@
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Certificate'
 		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCertificate'
+		)]
 		[X509Certificate]
 		$Certificate,
 
@@ -441,6 +518,11 @@
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'CertificateThumbPrint'
+		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCertificateThumbPrint'
 		)]
 		[string]
 		$CertificateThumbPrint,
@@ -471,6 +553,31 @@
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Certificate'
 		)]
+		[Parameter(
+			Mandatory = $false,
+			ValueFromPipelineByPropertyName = $true,
+			ParameterSetName = 'Query'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCredential'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryDefaultCredentials'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCertificateThumbPrint'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCertificate'
+		)]
 		[string]
 		$WebServiceName = 'AIMWebService',
 
@@ -499,6 +606,31 @@
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Certificate'
+		)]
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipelineByPropertyName = $true,
+			ParameterSetName = 'Query'
+		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCredential'
+		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryDefaultCredentials'
+		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCertificateThumbPrint'
+		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCertificate'
 		)]
 		[string]
 		$URL,
@@ -533,6 +665,36 @@
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Certificate'
 		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Query'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCredential'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryDefaultCredentials'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCertificateThumbPrint'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'QueryCertificate'
+		)]
 		[switch]$SkipCertificateCheck
 	)
 
@@ -559,21 +721,37 @@
 
 	Process {
 
-		[array]$QueryArgs = @()
+		Switch -Regex ($($PSCmdlet.ParameterSetName)) {
 
-		#Enumerate bound parameters to build query string for URL
-		$PSBoundParameters.keys | Where-Object { $CommonParameters -notcontains $_ } | ForEach-Object {
+			'^Query' {
 
-			$QueryArgs += "$_=$([System.Uri]::EscapeDataString($PSBoundParameters[$_]))"
+				$QueryString = $Query
+
+				break
+
+			}
+
+			default {
+
+				[array]$QueryArgs = @()
+
+				#Enumerate bound parameters to build query string for URL
+				$PSBoundParameters.keys | Where-Object { $CommonParameters -notcontains $_ } | ForEach-Object {
+
+					$QueryArgs += "$_=$([System.Uri]::EscapeDataString($PSBoundParameters[$_]))"
+
+				}
+
+				#Format URL query string
+				$QueryString = $QueryArgs -join '&'
+
+			}
 
 		}
 
-		#Format URL query string
-		$Query = $QueryArgs -join '&'
-
 		#Create hashtable of request parameters
 		$Request = @{
-			'URI'             = "$URL/$WebServiceName/api/Accounts?$Query"
+			'URI'             = "$URL/$WebServiceName/api/Accounts?$QueryString"
 			'Method'          = 'GET'
 			'ContentType'     = 'application/json'
 			'ErrorAction'     = 'Stop'
@@ -587,6 +765,10 @@
 			'DefaultCredentials' { $Request['UseDefaultCredentials'] = $true }
 			'CertificateThumbPrint' { $Request['CertificateThumbPrint'] = $CertificateThumbPrint }
 			'Certificate' { $Request['Certificate'] = $Certificate }
+			'QueryCredential' { $Request['Credential'] = $Credential }
+			'QueryDefaultCredentials' { $Request['UseDefaultCredentials'] = $true }
+			'QueryCertificateThumbPrint' { $Request['CertificateThumbPrint'] = $CertificateThumbPrint }
+			'QueryCertificate' { $Request['Certificate'] = $Certificate }
 		}
 
 		#in PSCore Use SslProtocol TLS1.2 & SkipCertificateCheck parameter

--- a/tests/Get-CCPCredential.Tests.ps1
+++ b/tests/Get-CCPCredential.Tests.ps1
@@ -65,6 +65,15 @@ InModuleScope $ModuleName {
 			} -Times 1 -Exactly -Scope It
 		}
 
+		It 'sends request with expected Query' {
+			Get-CCPCredential -Query 'AppID=PS&Object=PSP-AccountName&Safe=PS&QueryFormat=Exact' -URL 'https://SomeURL'
+			Assert-MockCalled Invoke-RestMethod -ParameterFilter {
+
+				$URI -eq 'https://SomeURL/AIMWebService/api/Accounts?AppID=PS&Object=PSP-AccountName&Safe=PS&QueryFormat=Exact'
+
+			} -Times 1 -Exactly -Scope It
+		}
+
 		It 'sends request to specified web service URL' {
 			$InputObj | Get-CCPCredential -WebServiceName DEV
 			Assert-MockCalled Invoke-RestMethod -ParameterFilter {

--- a/tests/Get-CCPCredential.Tests.ps1
+++ b/tests/Get-CCPCredential.Tests.ps1
@@ -119,9 +119,30 @@ InModuleScope $ModuleName {
 			} -Times 1 -Exactly -Scope It
 		}
 
+		It 'invokes rest method with query and credentials' {
+
+			$SomeCredential = New-Object System.Management.Automation.PSCredential('SomeUser', $('SomePassword' | ConvertTo-SecureString -AsPlainText -Force))
+			Get-CCPCredential -Query 'SomeQuery' -URL 'https://SomeURL' -Credential $SomeCredential
+			Assert-MockCalled Invoke-RestMethod -ParameterFilter {
+
+				$credential -eq $SomeCredential
+
+			} -Times 1 -Exactly -Scope It
+		}
+
 		It 'invokes rest method with default credentials switch' {
 
 			$InputObj | Get-CCPCredential -UseDefaultCredentials
+			Assert-MockCalled Invoke-RestMethod -ParameterFilter {
+
+				$UseDefaultCredentials -eq $true
+
+			} -Times 1 -Exactly -Scope It
+		}
+
+		It 'invokes rest method with query and default credentials switch' {
+
+			Get-CCPCredential -Query 'SomeQuery' -URL 'https://SomeURL' -UseDefaultCredentials
 			Assert-MockCalled Invoke-RestMethod -ParameterFilter {
 
 				$UseDefaultCredentials -eq $true
@@ -140,10 +161,32 @@ InModuleScope $ModuleName {
 			} -Times 1 -Exactly -Scope It
 		}
 
+		It 'invokes rest method with query and certificateThumbprint' {
+
+			$thumbprint = 'C1Y2BFE0R0ADR3KDR508C4KAS4C1YFB7EAR4ACRK'
+			Get-CCPCredential -Query 'SomeQuery' -URL 'https://SomeURL' -CertificateThumbPrint $thumbprint
+			Assert-MockCalled Invoke-RestMethod -ParameterFilter {
+
+				$certificateThumbprint -eq $thumbprint
+
+			} -Times 1 -Exactly -Scope It
+		}
+
 		It 'invokes rest method with certificate' {
 
 			$certificate = Get-ChildItem -Path Cert:\CurrentUser\My\ | Select-Object -First 1
 			$InputObj | Get-CCPCredential -Certificate $certificate
+			Assert-MockCalled Invoke-RestMethod -ParameterFilter {
+
+				$certificate -eq $certificate
+
+			} -Times 1 -Exactly -Scope It
+		}
+
+		It 'invokes rest method with query and certificate' {
+
+			$certificate = Get-ChildItem -Path Cert:\CurrentUser\My\ | Select-Object -First 1
+			Get-CCPCredential -Query 'SomeQuery' -URL 'https://SomeURL' -Certificate $certificate
 			Assert-MockCalled Invoke-RestMethod -ParameterFilter {
 
 				$certificate -eq $certificate


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

- Update `Get-CCPCredential`
  - Adds `Query` parameter to allow users to specify own query filter value to include in request URL.

Implements functionality described in #24 

## Test Plan

Pester tests updated and passing

## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Fixes #

Closes #

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->